### PR TITLE
fix: BasicBridge gas

### DIFF
--- a/src/BasicBridge.sol
+++ b/src/BasicBridge.sol
@@ -34,11 +34,8 @@ contract BasicBridge is Context {
         IERC20 renAsset = registry.getRenAssetBySymbol(symbol);
         IMintGateway mintGateway = registry.getMintGatewayBySymbol(symbol);
 
-        if (address(renAsset) == address(0x0)) {
+        if (address(renAsset) == address(0x0) || address(mintGateway) == address(0x0)) {
             revert(string(abi.encodePacked("BasicBridge: unknown asset ", symbol)));
-        }
-        if (address(mintGateway) != address(0x0)) {
-            string(abi.encodePacked("BasicBridge: unknown asset ", symbol));
         }
 
         bytes32 payloadHash = keccak256(abi.encode(symbol, recipient));
@@ -54,11 +51,8 @@ contract BasicBridge is Context {
         IERC20 renAsset = registry.getRenAssetBySymbol(symbol);
         IMintGateway mintGateway = registry.getMintGatewayBySymbol(symbol);
 
-        if (address(renAsset) == address(0x0)) {
+        if (address(renAsset) == address(0x0) || address(mintGateway) == address(0x0)) {
             revert(string(abi.encodePacked("BasicBridge: unknown asset ", symbol)));
-        }
-        if (address(mintGateway) != address(0x0)) {
-            string(abi.encodePacked("BasicBridge: unknown asset ", symbol));
         }
 
         renAsset.safeTransferFrom(_msgSender(), address(this), amount);
@@ -75,11 +69,8 @@ contract BasicBridge is Context {
         IERC20 lockAsset = registry.getLockAssetBySymbol(symbol);
         ILockGateway lockGateway = registry.getLockGatewayBySymbol(symbol);
 
-        if (address(lockAsset) == address(0x0)) {
+        if (address(lockAsset) == address(0x0) || address(lockGateway) == address(0x0)) {
             revert(string(abi.encodePacked("BasicBridge: unknown asset ", symbol)));
-        }
-        if (address(lockGateway) != address(0x0)) {
-            string(abi.encodePacked("BasicBridge: unknown asset ", symbol));
         }
 
         lockAsset.safeTransferFrom(_msgSender(), address(this), amount);
@@ -99,11 +90,8 @@ contract BasicBridge is Context {
         IERC20 lockAsset = registry.getLockAssetBySymbol(symbol);
         ILockGateway lockGateway = registry.getLockGatewayBySymbol(symbol);
 
-        if (address(lockAsset) == address(0x0)) {
+        if (address(lockAsset) == address(0x0) || address(lockGateway) == address(0x0)) {
             revert(string(abi.encodePacked("BasicBridge: unknown asset ", symbol)));
-        }
-        if (address(lockGateway) != address(0x0)) {
-            string(abi.encodePacked("BasicBridge: unknown asset ", symbol));
         }
 
         bytes32 payloadHash = keccak256(abi.encode(symbol, recipient));

--- a/src/BasicBridge.sol
+++ b/src/BasicBridge.sol
@@ -56,7 +56,7 @@ contract BasicBridge is Context {
         }
 
         renAsset.safeTransferFrom(_msgSender(), address(this), amount);
-        registry.getMintGatewayBySymbol(symbol).burn(recipient, amount);
+        mintGateway.burn(recipient, amount);
     }
 
     function lock(


### PR DESCRIPTION
This PR makes the following fixes and optimizations in BasicBridge:

1. `mint`, `burn`, `lock`, and `release` no longer execute the unused expression `string(abi.encodePacked("BasicBridge: unknown asset ", symbol))` for valid gateway addresses.
2. `mint`, `burn`, `lock`, and `release` now revert for gateways whose addresses match the zero address. Even though the asset address check would revert before the gateway address check, this fix might still be good practice in case of changes to `GatewayRegistry`'s `addMintGateway` function or `mintGatewayDetailsBySymbol` mapping.
3. `burn` now uses the already-defined `mintGateway` and removes a redundant `registry.getMintGatewayBySymbol(symbol)` lookup.