### PR TITLE
fixes/added erc721receivable interface for lock-gateways

### DIFF
--- a/src/Gateways/LockGateway.sol
+++ b/src/Gateways/LockGateway.sol
@@ -8,6 +8,7 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 import {StringsUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import {IERC721ReceiverUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol";
 import {SafeERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 import {SafeTransferWithFeesUpgradeable} from "./common/SafeTransferWithFees.sol";
@@ -21,7 +22,14 @@ import {String} from "../libraries/String.sol";
 /// approves assets being released by providing a digital signature.
 /// The balance of assets is assumed not to change without a transfer, so
 /// rebasing assets and assets with a demurrage fee are not supported.
-contract LockGatewayV4 is Initializable, ContextUpgradeable, GatewayStateV4, GatewayStateManagerV4, ILockGateway {
+contract LockGatewayV4 is
+    Initializable,
+    ContextUpgradeable,
+    GatewayStateV4,
+    GatewayStateManagerV4,
+    ILockGateway,
+    IERC721ReceiverUpgradeable
+{
     using SafeERC20Upgradeable for IERC20Upgradeable;
     using SafeTransferWithFeesUpgradeable for IERC20Upgradeable;
 
@@ -50,7 +58,7 @@ contract LockGatewayV4 is Initializable, ContextUpgradeable, GatewayStateV4, Gat
     ///        moved to.
     /// @param recipientPayload An optional payload to be passed to the
     ///        recipient chain along with the address.
-    /// @param amountOrTokenId The amount of the token being locked, in the 
+    /// @param amountOrTokenId The amount of the token being locked, in the
     ///        asset's smallest unit or tokenId if it is an NFT. (e.g. satoshis 
     ///        for BTC)
     function lock(
@@ -105,7 +113,7 @@ contract LockGatewayV4 is Initializable, ContextUpgradeable, GatewayStateV4, Gat
     ///
     /// @param pHash (payload hash) The hash of the payload associated with the
     ///        release.
-    /// @param amountOrTokenId The amount of the token being released, in its 
+    /// @param amountOrTokenId The amount of the token being released, in its
     ///        smallest value or the token id of the NFT.
     /// @param nHash (nonce hash) The hash of the nonce, amount and pHash.
     /// @param sig The signature of the hash of the following values:
@@ -163,5 +171,14 @@ contract LockGatewayV4 is Initializable, ContextUpgradeable, GatewayStateV4, Gat
         emit LogRelease(recipient, amountOrTokenId, sigHash, nHash);
 
         return amountOrTokenId;
+    }
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return this.onERC721Received.selector;
     }
 }

--- a/src/testUtils/TestERC721.sol
+++ b/src/testUtils/TestERC721.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// solhint-disable-next-line
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract TestERC721 is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
+    constructor(string memory name,string memory symbol) ERC721(name, symbol) {}
+
+    function safeMint(
+        address to,
+        uint256 tokenId,
+        string memory uri
+    ) public onlyOwner {
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri);
+    }
+
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override(ERC721, ERC721Enumerable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
+        super._burn(tokenId);
+    }
+
+    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+        return super.tokenURI(tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}


### PR DESCRIPTION
- The ERC721Receivable interface allows the lock gateways to accept ERC721 token safe transfers.
- TestERC721.sol is a test utility contract.